### PR TITLE
Update to exact free models from OpenRouter

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,30 +1,32 @@
 import type { ModelOption } from '../types';
 
 export const AVAILABLE_MODELS: ModelOption[] = [
-  // Google
-  { id: 'google/gemini-2.5-pro-exp-03-25:free', name: 'Gemini 2.5 Pro', provider: 'Google' },
-  { id: 'google/gemma-3-27b-it:free', name: 'Gemma 3 27B', provider: 'Google' },
-  // Meta
-  { id: 'meta-llama/llama-4-maverick:free', name: 'Llama 4 Maverick', provider: 'Meta' },
-  { id: 'meta-llama/llama-4-scout:free', name: 'Llama 4 Scout', provider: 'Meta' },
+  // TNG Tech
+  { id: 'tngtech/deepseek-r1t2-chimera:free', name: 'DeepSeek R1T2 Chimera', provider: 'TNG Tech' },
+  { id: 'tngtech/deepseek-r1t-chimera:free', name: 'DeepSeek R1T Chimera', provider: 'TNG Tech' },
+  { id: 'tngtech/r1t-chimera:free', name: 'R1T Chimera', provider: 'TNG Tech' },
+  // Arcee AI
+  { id: 'arcee-ai/trinity-large-preview:free', name: 'Trinity Large Preview', provider: 'Arcee AI' },
+  // Z.AI
+  { id: 'z-ai/glm-4.5-air:free', name: 'GLM 4.5 Air', provider: 'Z.AI' },
   // DeepSeek
-  { id: 'deepseek/deepseek-chat-v3-0324:free', name: 'DeepSeek V3', provider: 'DeepSeek' },
-  { id: 'deepseek/deepseek-r1-zero:free', name: 'DeepSeek R1 Zero', provider: 'DeepSeek' },
-  // Mistral
-  { id: 'mistralai/mistral-small-3.1-24b-instruct:free', name: 'Mistral Small 3.1 24B', provider: 'Mistral' },
+  { id: 'deepseek/deepseek-r1-0528:free', name: 'DeepSeek R1 0528', provider: 'DeepSeek' },
   // NVIDIA
-  { id: 'nvidia/llama-3.1-nemotron-nano-8b-v1:free', name: 'Nemotron Nano 8B', provider: 'NVIDIA' },
+  { id: 'nvidia/nemotron-3-nano-30b-a3b:free', name: 'Nemotron 3 Nano 30B A3B', provider: 'NVIDIA' },
+  // Meta
+  { id: 'meta-llama/llama-3.3-70b-instruct:free', name: 'Llama 3.3 70B Instruct', provider: 'Meta' },
+  // Google
+  { id: 'google/gemma-3-27b-it:free', name: 'Gemma 3 27B', provider: 'Google' },
+  // OpenAI
+  { id: 'openai/gpt-oss-120b:free', name: 'GPT-OSS 120B', provider: 'OpenAI' },
   // Qwen
-  { id: 'qwen/qwen3-235b-a22b:free', name: 'Qwen3 235B', provider: 'Qwen' },
-  { id: 'qwen/qwen2.5-vl-3b-instruct:free', name: 'Qwen 2.5 VL 3B', provider: 'Qwen' },
-  // Nous Research
-  { id: 'nousresearch/deephermes-3-llama-3-8b-preview:free', name: 'DeepHermes 3 8B', provider: 'Nous Research' },
-  // Moonshot
-  { id: 'moonshotai/kimi-vl-a3b-thinking:free', name: 'Kimi VL A3B Thinking', provider: 'Moonshot' },
+  { id: 'qwen/qwen3-coder-480b-a35b:free', name: 'Qwen3 Coder 480B A35B', provider: 'Qwen' },
+  // Upstage
+  { id: 'upstage/solar-pro-3:free', name: 'Solar Pro 3', provider: 'Upstage' },
 ];
 
 export const DEFAULT_SETTINGS = {
-  model: 'google/gemini-2.5-pro-exp-03-25:free',
+  model: 'tngtech/deepseek-r1t2-chimera:free',
   systemPrompt: '',
   temperature: 0.7,
   apiKey: '',


### PR DESCRIPTION
This pull request updates the list of available AI models in the `AVAILABLE_MODELS` constant and changes the default model in the `DEFAULT_SETTINGS` object. Several previous models have been removed and replaced with newer or alternative models from a range of providers.

**Model list updates:**

* Removed models from Google, Meta, DeepSeek, Mistral, NVIDIA, Qwen, Nous Research, and Moonshot, including `google/gemini-2.5-pro-exp-03-25:free`, `meta-llama/llama-4-maverick:free`, and others.
* Added new models from TNG Tech (`deepseek-r1t2-chimera`, `deepseek-r1t-chimera`, `r1t-chimera`), Arcee AI (`trinity-large-preview`), Z.AI (`glm-4.5-air`), DeepSeek (`deepseek-r1-0528`), NVIDIA (`nemotron-3-nano-30b-a3b`), Meta (`llama-3.3-70b-instruct`), Google (`gemma-3-27b-it:free`), OpenAI (`gpt-oss-120b`), Qwen (`qwen3-coder-480b-a35b`), and Upstage (`solar-pro-3`).

**Default settings