### PR TITLE
Add tool calling UI with schema editor, guide, and mock execution

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,10 +4,13 @@ import ChatMessage from './components/ChatMessage';
 import ChatInput from './components/ChatInput';
 import SettingsPanel from './components/SettingsPanel';
 import ExportMenu from './components/ExportMenu';
+import ToolEditor from './components/ToolEditor';
+import ToolGuide from './components/ToolGuide';
 import { useLocalStorage } from './hooks/useLocalStorage';
 import { sendMessage } from './utils/api';
+import { executeMockTool } from './utils/mockTools';
 import { DEFAULT_SETTINGS } from './utils/constants';
-import type { Chat, ChatSettings, Message } from './types';
+import type { Chat, ChatSettings, Message, ToolDefinition } from './types';
 
 function generateId() {
   return crypto.randomUUID();
@@ -28,10 +31,17 @@ export default function App() {
   const [chats, setChats] = useLocalStorage<Chat[]>('ai-testing-chats', []);
   const [activeChatId, setActiveChatId] = useLocalStorage<string | null>('ai-testing-active', null);
   const [globalSettings, setGlobalSettings] = useLocalStorage<ChatSettings>('ai-testing-settings', DEFAULT_SETTINGS);
+  const [tools, setTools] = useLocalStorage<ToolDefinition[]>('ai-testing-tools', []);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Map of toolCallId -> { name, result } for rendering
+  const [toolResultsMap, setToolResultsMap] = useLocalStorage<Record<string, { name: string; result: string }>>(
+    'ai-testing-tool-results',
+    {},
+  );
 
   const activeChat = chats.find((c) => c.id === activeChatId) ?? null;
 
@@ -101,20 +111,69 @@ export default function App() {
     setLoading(true);
     try {
       const currentSettings = activeChat.settings;
-      const allMessages = [...activeChat.messages, userMessage];
-      const responseContent = await sendMessage(allMessages, currentSettings);
+      let allMessages = [...activeChat.messages, userMessage];
 
-      const assistantMessage: Message = {
-        id: generateId(),
-        role: 'assistant',
-        content: responseContent,
-        timestamp: Date.now(),
-        model: currentSettings.model,
-      };
+      // Loop to handle tool calls — model may call tools, we mock and re-send
+      let maxRounds = 5;
+      const newMessages: Message[] = [userMessage];
+      const newResults: Record<string, { name: string; result: string }> = {};
+
+      while (maxRounds > 0) {
+        maxRounds--;
+        const response = await sendMessage(allMessages, currentSettings, tools.length > 0 ? tools : undefined);
+
+        if (response.toolCalls && response.toolCalls.length > 0) {
+          // Assistant message with tool calls
+          const assistantMsg: Message = {
+            id: generateId(),
+            role: 'assistant',
+            content: response.content || '',
+            timestamp: Date.now(),
+            model: currentSettings.model,
+            toolCalls: response.toolCalls,
+          };
+          newMessages.push(assistantMsg);
+          allMessages = [...allMessages, assistantMsg];
+
+          // Mock execute each tool and create tool result messages
+          for (const call of response.toolCalls) {
+            const mockResult = executeMockTool(call.function.name, call.function.arguments);
+            newResults[call.id] = { name: call.function.name, result: mockResult };
+
+            const toolMsg: Message = {
+              id: generateId(),
+              role: 'tool',
+              content: mockResult,
+              timestamp: Date.now(),
+              toolCallId: call.id,
+              toolName: call.function.name,
+            };
+            newMessages.push(toolMsg);
+            allMessages = [...allMessages, toolMsg];
+          }
+          // Continue loop so model can produce final answer
+        } else {
+          // Final text response
+          const assistantMsg: Message = {
+            id: generateId(),
+            role: 'assistant',
+            content: response.content || 'No response received.',
+            timestamp: Date.now(),
+            model: currentSettings.model,
+          };
+          newMessages.push(assistantMsg);
+          break;
+        }
+      }
+
+      // Persist tool results
+      if (Object.keys(newResults).length > 0) {
+        setToolResultsMap((prev) => ({ ...prev, ...newResults }));
+      }
 
       updateChat(activeChat.id, (c) => ({
         ...c,
-        messages: [...c.messages, userMessage, assistantMessage],
+        messages: [...c.messages, ...newMessages],
         updatedAt: Date.now(),
         title: isFirstMessage ? title : c.title,
       }));
@@ -126,6 +185,7 @@ export default function App() {
   };
 
   const displayChat = chats.find((c) => c.id === activeChatId) ?? null;
+  const resultsMap = new Map(Object.entries(toolResultsMap));
 
   return (
     <div className="app">
@@ -153,6 +213,8 @@ export default function App() {
               onChange={handleSettingsChange}
               open={settingsOpen}
               onToggle={() => setSettingsOpen(!settingsOpen)}
+              toolEditor={<ToolEditor tools={tools} onChange={setTools} />}
+              toolGuide={<ToolGuide />}
             />
           </div>
         </header>
@@ -171,13 +233,16 @@ export default function App() {
               <h2>New Conversation</h2>
               <p>
                 Using <strong>{displayChat.settings.model.split('/').pop()}</strong>.
-                Configure settings or start typing below.
+                {tools.length > 0 && (
+                  <> With <strong>{tools.length} tool{tools.length > 1 ? 's' : ''}</strong> enabled.</>
+                )}
+                {' '}Configure settings or start typing below.
               </p>
             </div>
           ) : (
             <div className="messages-list">
               {displayChat.messages.map((msg) => (
-                <ChatMessage key={msg.id} message={msg} />
+                <ChatMessage key={msg.id} message={msg} toolResults={resultsMap} />
               ))}
               {loading && (
                 <div className="chat-message assistant">

--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -1,16 +1,21 @@
-import { Bot, User } from 'lucide-react';
+import { Bot, User, Wrench } from 'lucide-react';
 import type { Message } from '../types';
+import ToolCallMessage from './ToolCallMessage';
 
 interface ChatMessageProps {
   message: Message;
+  toolResults?: Map<string, { name: string; result: string }>;
 }
 
-export default function ChatMessage({ message }: ChatMessageProps) {
+export default function ChatMessage({ message, toolResults }: ChatMessageProps) {
   const isUser = message.role === 'user';
+  const isTool = message.role === 'tool';
   const time = new Date(message.timestamp).toLocaleTimeString([], {
     hour: '2-digit',
     minute: '2-digit',
   });
+
+  if (isTool) return null;
 
   return (
     <div className={`chat-message ${isUser ? 'user' : 'assistant'}`}>
@@ -23,9 +28,22 @@ export default function ChatMessage({ message }: ChatMessageProps) {
           {message.model && !isUser && (
             <span className="message-model">{message.model}</span>
           )}
+          {message.toolCalls && message.toolCalls.length > 0 && (
+            <span className="message-badge tool-badge">
+              <Wrench size={11} /> Tool Call
+            </span>
+          )}
           <span className="message-time">{time}</span>
         </div>
-        <div className="message-content">{message.content}</div>
+        {message.content && (
+          <div className="message-content">{message.content}</div>
+        )}
+        {message.toolCalls && message.toolCalls.length > 0 && (
+          <ToolCallMessage
+            toolCalls={message.toolCalls}
+            toolResults={toolResults ?? new Map()}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,5 +1,5 @@
 import { Settings, Eye, EyeOff } from 'lucide-react';
-import { useState } from 'react';
+import { useState, type ReactNode } from 'react';
 import { AVAILABLE_MODELS } from '../utils/constants';
 import type { ChatSettings } from '../types';
 
@@ -8,9 +8,11 @@ interface SettingsPanelProps {
   onChange: (settings: ChatSettings) => void;
   open: boolean;
   onToggle: () => void;
+  toolEditor?: ReactNode;
+  toolGuide?: ReactNode;
 }
 
-export default function SettingsPanel({ settings, onChange, open, onToggle }: SettingsPanelProps) {
+export default function SettingsPanel({ settings, onChange, open, onToggle, toolEditor, toolGuide }: SettingsPanelProps) {
   const [showKey, setShowKey] = useState(false);
 
   const grouped = AVAILABLE_MODELS.reduce<Record<string, typeof AVAILABLE_MODELS>>((acc, m) => {
@@ -96,6 +98,11 @@ export default function SettingsPanel({ settings, onChange, open, onToggle }: Se
           rows={4}
         />
       </label>
+
+      <div className="settings-divider" />
+
+      {toolGuide}
+      {toolEditor}
     </div>
   );
 }

--- a/src/components/ToolCallMessage.tsx
+++ b/src/components/ToolCallMessage.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Wrench, ChevronDown, ChevronRight, CheckCircle } from 'lucide-react';
+import type { ToolCall } from '../types';
+
+interface ToolCallMessageProps {
+  toolCalls: ToolCall[];
+  toolResults: Map<string, { name: string; result: string }>;
+}
+
+function formatJson(str: string): string {
+  try {
+    return JSON.stringify(JSON.parse(str), null, 2);
+  } catch {
+    return str;
+  }
+}
+
+function SingleToolCall({
+  call,
+  result,
+}: {
+  call: ToolCall;
+  result?: { name: string; result: string };
+}) {
+  const [expanded, setExpanded] = useState(true);
+
+  return (
+    <div className="tool-call-block">
+      <div className="tool-call-header" onClick={() => setExpanded(!expanded)}>
+        {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <Wrench size={14} />
+        <span className="tool-call-fn">{call.function.name}</span>
+        {result && <CheckCircle size={14} className="tool-call-done" />}
+      </div>
+      {expanded && (
+        <div className="tool-call-body">
+          <div className="tool-call-section">
+            <span className="tool-call-label">Arguments</span>
+            <pre className="tool-call-code">{formatJson(call.function.arguments)}</pre>
+          </div>
+          {result && (
+            <div className="tool-call-section">
+              <span className="tool-call-label">Result</span>
+              <pre className="tool-call-code tool-call-result">{formatJson(result.result)}</pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function ToolCallMessage({ toolCalls, toolResults }: ToolCallMessageProps) {
+  return (
+    <div className="tool-calls-container">
+      {toolCalls.map((call) => (
+        <SingleToolCall
+          key={call.id}
+          call={call}
+          result={toolResults.get(call.id)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ToolEditor.tsx
+++ b/src/components/ToolEditor.tsx
@@ -1,0 +1,301 @@
+import { useState } from 'react';
+import { Plus, Trash2, Wrench, ChevronDown, ChevronRight, Copy, RotateCcw } from 'lucide-react';
+import type { ToolDefinition, ToolParameter } from '../types';
+import { PRESET_TOOLS } from '../utils/mockTools';
+
+interface ToolEditorProps {
+  tools: ToolDefinition[];
+  onChange: (tools: ToolDefinition[]) => void;
+}
+
+function generateId() {
+  return crypto.randomUUID();
+}
+
+function emptyTool(): ToolDefinition {
+  return {
+    id: generateId(),
+    name: '',
+    description: '',
+    parameters: {},
+    required: [],
+  };
+}
+
+function ParamEditor({
+  params,
+  required,
+  onChangeParams,
+  onChangeRequired,
+}: {
+  params: Record<string, ToolParameter>;
+  required: string[];
+  onChangeParams: (p: Record<string, ToolParameter>) => void;
+  onChangeRequired: (r: string[]) => void;
+}) {
+  const [newName, setNewName] = useState('');
+
+  const addParam = () => {
+    const name = newName.trim();
+    if (!name || params[name]) return;
+    onChangeParams({ ...params, [name]: { type: 'string', description: '' } });
+    setNewName('');
+  };
+
+  const removeParam = (name: string) => {
+    const next = { ...params };
+    delete next[name];
+    onChangeParams(next);
+    onChangeRequired(required.filter((r) => r !== name));
+  };
+
+  const updateParam = (name: string, field: keyof ToolParameter, value: string) => {
+    const updated = { ...params[name] };
+    if (field === 'enum') {
+      updated.enum = value ? value.split(',').map((s) => s.trim()) : undefined;
+    } else if (field === 'type') {
+      updated.type = value;
+    } else if (field === 'description') {
+      updated.description = value;
+    }
+    onChangeParams({ ...params, [name]: updated });
+  };
+
+  const toggleRequired = (name: string) => {
+    if (required.includes(name)) {
+      onChangeRequired(required.filter((r) => r !== name));
+    } else {
+      onChangeRequired([...required, name]);
+    }
+  };
+
+  return (
+    <div className="param-editor">
+      <div className="param-list">
+        {Object.entries(params).map(([name, param]) => (
+          <div key={name} className="param-item">
+            <div className="param-item-header">
+              <code className="param-name">{name}</code>
+              <select
+                className="param-type-select"
+                value={param.type}
+                onChange={(e) => updateParam(name, 'type', e.target.value)}
+              >
+                <option value="string">string</option>
+                <option value="number">number</option>
+                <option value="boolean">boolean</option>
+                <option value="integer">integer</option>
+              </select>
+              <label className="param-required-label">
+                <input
+                  type="checkbox"
+                  checked={required.includes(name)}
+                  onChange={() => toggleRequired(name)}
+                />
+                required
+              </label>
+              <button className="param-remove-btn" onClick={() => removeParam(name)} title="Remove parameter">
+                <Trash2 size={12} />
+              </button>
+            </div>
+            <input
+              className="param-desc-input"
+              type="text"
+              value={param.description}
+              onChange={(e) => updateParam(name, 'description', e.target.value)}
+              placeholder="Description..."
+            />
+            {param.type === 'string' && (
+              <input
+                className="param-desc-input"
+                type="text"
+                value={param.enum?.join(', ') ?? ''}
+                onChange={(e) => updateParam(name, 'enum', e.target.value)}
+                placeholder="Enum values (comma-separated, optional)"
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <div className="add-param-row">
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && addParam()}
+          placeholder="Parameter name..."
+          className="param-name-input"
+        />
+        <button className="add-param-btn" onClick={addParam} disabled={!newName.trim()}>
+          <Plus size={14} /> Add
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function ToolEditor({ tools, onChange }: ToolEditorProps) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [jsonMode, setJsonMode] = useState<string | null>(null);
+  const [jsonText, setJsonText] = useState('');
+  const [jsonError, setJsonError] = useState<string | null>(null);
+
+  const addTool = () => {
+    const tool = emptyTool();
+    onChange([...tools, tool]);
+    setExpandedId(tool.id);
+  };
+
+  const addPreset = (preset: ToolDefinition) => {
+    if (tools.some((t) => t.name === preset.name)) return;
+    const tool = { ...preset, id: generateId() };
+    onChange([...tools, tool]);
+  };
+
+  const removeTool = (id: string) => {
+    onChange(tools.filter((t) => t.id !== id));
+    if (expandedId === id) setExpandedId(null);
+    if (jsonMode === id) setJsonMode(null);
+  };
+
+  const updateTool = (id: string, updates: Partial<ToolDefinition>) => {
+    onChange(tools.map((t) => (t.id === id ? { ...t, ...updates } : t)));
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedId(expandedId === id ? null : id);
+    setJsonMode(null);
+  };
+
+  const openJsonEditor = (tool: ToolDefinition) => {
+    const { id, ...rest } = tool;
+    void id;
+    setJsonText(JSON.stringify(rest, null, 2));
+    setJsonError(null);
+    setJsonMode(tool.id);
+  };
+
+  const saveJson = (id: string) => {
+    try {
+      const parsed = JSON.parse(jsonText);
+      updateTool(id, {
+        name: parsed.name ?? '',
+        description: parsed.description ?? '',
+        parameters: parsed.parameters ?? {},
+        required: parsed.required ?? [],
+      });
+      setJsonMode(null);
+      setJsonError(null);
+    } catch (e) {
+      setJsonError(e instanceof Error ? e.message : 'Invalid JSON');
+    }
+  };
+
+  const loadAllPresets = () => {
+    const existing = new Set(tools.map((t) => t.name));
+    const toAdd = PRESET_TOOLS.filter((p) => !existing.has(p.name)).map((p) => ({ ...p, id: generateId() }));
+    onChange([...tools, ...toAdd]);
+  };
+
+  return (
+    <div className="tool-editor">
+      <div className="tool-editor-header">
+        <h4><Wrench size={14} /> Tools ({tools.length})</h4>
+        <div className="tool-editor-actions">
+          <button className="tool-small-btn" onClick={loadAllPresets} title="Load all preset tools">
+            <RotateCcw size={13} /> Presets
+          </button>
+          <button className="tool-small-btn" onClick={addTool} title="Add custom tool">
+            <Plus size={13} /> New
+          </button>
+        </div>
+      </div>
+
+      {tools.length === 0 && (
+        <div className="tool-empty">
+          <p>No tools defined. Add presets or create custom tools.</p>
+          <div className="preset-chips">
+            {PRESET_TOOLS.map((p) => (
+              <button key={p.id} className="preset-chip" onClick={() => addPreset(p)}>
+                + {p.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="tool-list">
+        {tools.map((tool) => (
+          <div key={tool.id} className="tool-card">
+            <div className="tool-card-header" onClick={() => toggleExpand(tool.id)}>
+              {expandedId === tool.id ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <span className="tool-card-name">{tool.name || 'Unnamed tool'}</span>
+              <span className="tool-card-params">{Object.keys(tool.parameters).length} params</span>
+              <button
+                className="param-remove-btn"
+                onClick={(e) => { e.stopPropagation(); removeTool(tool.id); }}
+                title="Remove tool"
+              >
+                <Trash2 size={13} />
+              </button>
+            </div>
+
+            {expandedId === tool.id && (
+              <div className="tool-card-body">
+                {jsonMode === tool.id ? (
+                  <div className="json-editor">
+                    <textarea
+                      className="json-textarea"
+                      value={jsonText}
+                      onChange={(e) => { setJsonText(e.target.value); setJsonError(null); }}
+                      rows={12}
+                      spellCheck={false}
+                    />
+                    {jsonError && <p className="json-error">{jsonError}</p>}
+                    <div className="json-editor-actions">
+                      <button className="tool-small-btn" onClick={() => saveJson(tool.id)}>Save JSON</button>
+                      <button className="tool-small-btn" onClick={() => setJsonMode(null)}>Cancel</button>
+                    </div>
+                  </div>
+                ) : (
+                  <>
+                    <div className="tool-field">
+                      <label>Function name</label>
+                      <input
+                        type="text"
+                        value={tool.name}
+                        onChange={(e) => updateTool(tool.id, { name: e.target.value })}
+                        placeholder="e.g. get_weather"
+                      />
+                    </div>
+                    <div className="tool-field">
+                      <label>Description</label>
+                      <input
+                        type="text"
+                        value={tool.description}
+                        onChange={(e) => updateTool(tool.id, { description: e.target.value })}
+                        placeholder="What does this tool do?"
+                      />
+                    </div>
+                    <div className="tool-field">
+                      <label>Parameters</label>
+                      <ParamEditor
+                        params={tool.parameters}
+                        required={tool.required}
+                        onChangeParams={(p) => updateTool(tool.id, { parameters: p })}
+                        onChangeRequired={(r) => updateTool(tool.id, { required: r })}
+                      />
+                    </div>
+                    <button className="tool-small-btn json-toggle" onClick={() => openJsonEditor(tool)}>
+                      <Copy size={12} /> Edit as JSON
+                    </button>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ToolGuide.tsx
+++ b/src/components/ToolGuide.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react';
+import { BookOpen, ChevronDown, ChevronRight } from 'lucide-react';
+
+export default function ToolGuide() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="tool-guide">
+      <button className="tool-guide-toggle" onClick={() => setOpen(!open)}>
+        <BookOpen size={14} />
+        <span>Tool Calling Guide</span>
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+      </button>
+
+      {open && (
+        <div className="tool-guide-content">
+          <section>
+            <h5>What are Tool Calls?</h5>
+            <p>
+              Tool calling (function calling) lets AI models request external actions during a
+              conversation. Instead of just generating text, the model can invoke defined functions
+              with structured arguments, receive results, and use them in its response.
+            </p>
+          </section>
+
+          <section>
+            <h5>How it Works Here</h5>
+            <ol>
+              <li>Define tools in the <strong>Tools</strong> section of the settings panel</li>
+              <li>Send a message that might need a tool (e.g. "What's the weather in Tokyo?")</li>
+              <li>If the model decides to use a tool, the call is shown in the chat</li>
+              <li>A <strong>mock result</strong> is automatically generated (no real execution)</li>
+              <li>The mock result is fed back to the model to produce a final answer</li>
+            </ol>
+          </section>
+
+          <section>
+            <h5>Tool Schema Format</h5>
+            <p>Each tool needs:</p>
+            <ul>
+              <li><strong>Name</strong> — Function identifier (e.g. <code>get_weather</code>)</li>
+              <li><strong>Description</strong> — What the function does</li>
+              <li><strong>Parameters</strong> — Named inputs with type and description</li>
+              <li><strong>Required</strong> — Which parameters are mandatory</li>
+            </ul>
+          </section>
+
+          <section>
+            <h5>JSON Schema Example</h5>
+            <pre className="guide-code">{`{
+  "name": "get_weather",
+  "description": "Get current weather for a location",
+  "parameters": {
+    "location": {
+      "type": "string",
+      "description": "City name"
+    },
+    "unit": {
+      "type": "string",
+      "description": "Temperature unit",
+      "enum": ["celsius", "fahrenheit"]
+    }
+  },
+  "required": ["location"]
+}`}</pre>
+          </section>
+
+          <section>
+            <h5>Tips</h5>
+            <ul>
+              <li>Use <strong>Presets</strong> to quickly load example tools</li>
+              <li>You can also <strong>Edit as JSON</strong> for full control over the schema</li>
+              <li>All tool results are <strong>mocked</strong> — no real APIs are called</li>
+              <li>Not all models support tool calling — larger models work best</li>
+            </ul>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -628,6 +628,522 @@ body {
   background: var(--bg-hover);
 }
 
+/* ===== Settings Divider ===== */
+.settings-divider {
+  height: 1px;
+  background: var(--border);
+  margin: 4px 0;
+}
+
+/* ===== Tool Guide ===== */
+.tool-guide {
+  margin-bottom: 4px;
+}
+
+.tool-guide-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 8px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.tool-guide-toggle:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.tool-guide-content {
+  margin-top: 8px;
+  padding: 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.tool-guide-content section {
+  margin-bottom: 14px;
+}
+
+.tool-guide-content section:last-child {
+  margin-bottom: 0;
+}
+
+.tool-guide-content h5 {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.tool-guide-content ol,
+.tool-guide-content ul {
+  padding-left: 18px;
+}
+
+.tool-guide-content li {
+  margin-bottom: 2px;
+}
+
+.tool-guide-content code {
+  background: var(--bg-hover);
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.guide-code {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  overflow-x: auto;
+  line-height: 1.5;
+  color: var(--text-primary);
+  white-space: pre;
+}
+
+/* ===== Tool Editor ===== */
+.tool-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tool-editor-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.tool-editor-header h4 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.tool-editor-actions {
+  display: flex;
+  gap: 6px;
+}
+
+.tool-small-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition), color var(--transition);
+}
+
+.tool-small-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.tool-small-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.tool-empty {
+  text-align: center;
+  padding: 12px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.preset-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+  justify-content: center;
+}
+
+.preset-chip {
+  padding: 4px 10px;
+  background: var(--accent-glow);
+  border: 1px solid rgba(124, 92, 252, 0.3);
+  border-radius: 12px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background var(--transition);
+}
+
+.preset-chip:hover {
+  background: rgba(124, 92, 252, 0.35);
+}
+
+.tool-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.tool-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.tool-card-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary);
+  transition: background var(--transition);
+}
+
+.tool-card-header:hover {
+  background: var(--bg-hover);
+}
+
+.tool-card-name {
+  flex: 1;
+  font-weight: 500;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+}
+
+.tool-card-params {
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-right: 4px;
+}
+
+.tool-card-body {
+  padding: 10px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tool-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tool-field label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tool-field input[type="text"] {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+  transition: border-color var(--transition);
+}
+
+.tool-field input[type="text"]:focus {
+  border-color: var(--accent);
+}
+
+.json-toggle {
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
+.json-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.json-textarea {
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  line-height: 1.5;
+  resize: vertical;
+  outline: none;
+}
+
+.json-textarea:focus {
+  border-color: var(--accent);
+}
+
+.json-error {
+  color: var(--error);
+  font-size: 11px;
+}
+
+.json-editor-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ===== Parameter Editor ===== */
+.param-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.param-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.param-item {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.param-item-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.param-name {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--accent);
+  flex: 1;
+}
+
+.param-type-select {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 2px 4px;
+  font-size: 11px;
+  font-family: inherit;
+  outline: none;
+}
+
+.param-required-label {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.param-required-label input {
+  accent-color: var(--accent);
+}
+
+.param-remove-btn {
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: 3px;
+  display: flex;
+  transition: color var(--transition);
+}
+
+.param-remove-btn:hover {
+  color: var(--error);
+}
+
+.param-desc-input {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 4px 6px;
+  font-size: 11px;
+  font-family: inherit;
+  outline: none;
+}
+
+.param-desc-input:focus {
+  border-color: var(--accent);
+}
+
+.add-param-row {
+  display: flex;
+  gap: 6px;
+}
+
+.param-name-input {
+  flex: 1;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 5px 8px;
+  font-size: 12px;
+  font-family: inherit;
+  outline: none;
+}
+
+.param-name-input:focus {
+  border-color: var(--accent);
+}
+
+.add-param-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 4px 10px;
+  background: var(--accent-glow);
+  border: 1px solid rgba(124, 92, 252, 0.3);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+}
+
+.add-param-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ===== Tool Call Rendering (Chat) ===== */
+.tool-calls-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.tool-call-block {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.tool-call-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-primary);
+  transition: background var(--transition);
+}
+
+.tool-call-header:hover {
+  background: var(--bg-hover);
+}
+
+.tool-call-fn {
+  font-weight: 600;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  font-size: 12px;
+  color: var(--accent);
+}
+
+.tool-call-done {
+  color: var(--success);
+  margin-left: auto;
+}
+
+.tool-call-body {
+  padding: 8px 10px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tool-call-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.tool-call-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.tool-call-code {
+  background: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 8px;
+  font-size: 11px;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre;
+  color: var(--text-primary);
+}
+
+.tool-call-result {
+  border-left: 3px solid var(--success);
+}
+
+.message-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 11px;
+  padding: 1px 8px;
+  border-radius: 10px;
+}
+
+.tool-badge {
+  background: var(--accent-glow);
+  color: var(--accent);
+  border: 1px solid rgba(124, 92, 252, 0.3);
+}
+
 /* ===== Scrollbar ===== */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,9 +1,12 @@
 export interface Message {
   id: string;
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'tool';
   content: string;
   timestamp: number;
   model?: string;
+  toolCalls?: ToolCall[];
+  toolCallId?: string;
+  toolName?: string;
 }
 
 export interface Chat {
@@ -26,4 +29,26 @@ export interface ModelOption {
   id: string;
   name: string;
   provider: string;
+}
+
+export interface ToolParameter {
+  type: string;
+  description: string;
+  enum?: string[];
+}
+
+export interface ToolDefinition {
+  id: string;
+  name: string;
+  description: string;
+  parameters: Record<string, ToolParameter>;
+  required: string[];
+}
+
+export interface ToolCall {
+  id: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
 }

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,23 +1,63 @@
-import type { Message, ChatSettings } from '../types';
+import type { Message, ChatSettings, ToolDefinition, ToolCall } from '../types';
+import { toolDefinitionsToApiFormat } from './mockTools';
+
+export interface ApiResponse {
+  content: string | null;
+  toolCalls: ToolCall[] | null;
+}
+
+interface ApiMessage {
+  role: string;
+  content: string;
+  tool_call_id?: string;
+  name?: string;
+  tool_calls?: ToolCall[];
+}
 
 export async function sendMessage(
   messages: Message[],
   settings: ChatSettings,
-): Promise<string> {
+  tools?: ToolDefinition[],
+): Promise<ApiResponse> {
   if (!settings.apiKey) {
     throw new Error('Please enter your OpenRouter API key in the settings panel.');
   }
 
-  const apiMessages = [];
+  const apiMessages: ApiMessage[] = [];
 
   if (settings.systemPrompt) {
-    apiMessages.push({ role: 'system' as const, content: settings.systemPrompt });
+    apiMessages.push({ role: 'system', content: settings.systemPrompt });
   }
 
   for (const msg of messages) {
-    if (msg.role !== 'system') {
+    if (msg.role === 'system') continue;
+
+    if (msg.role === 'tool') {
+      apiMessages.push({
+        role: 'tool',
+        content: msg.content,
+        tool_call_id: msg.toolCallId,
+        name: msg.toolName,
+      });
+    } else if (msg.role === 'assistant' && msg.toolCalls?.length) {
+      apiMessages.push({
+        role: 'assistant',
+        content: msg.content || '',
+        tool_calls: msg.toolCalls,
+      });
+    } else {
       apiMessages.push({ role: msg.role, content: msg.content });
     }
+  }
+
+  const body: Record<string, unknown> = {
+    model: settings.model,
+    messages: apiMessages,
+    temperature: settings.temperature,
+  };
+
+  if (tools && tools.length > 0) {
+    body.tools = toolDefinitionsToApiFormat(tools);
   }
 
   const response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
@@ -26,11 +66,7 @@ export async function sendMessage(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${settings.apiKey}`,
     },
-    body: JSON.stringify({
-      model: settings.model,
-      messages: apiMessages,
-      temperature: settings.temperature,
-    }),
+    body: JSON.stringify(body),
   });
 
   if (!response.ok) {
@@ -41,5 +77,10 @@ export async function sendMessage(
   }
 
   const data = await response.json();
-  return data.choices?.[0]?.message?.content || 'No response received.';
+  const choice = data.choices?.[0]?.message;
+
+  return {
+    content: choice?.content || null,
+    toolCalls: choice?.tool_calls || null,
+  };
 }

--- a/src/utils/mockTools.ts
+++ b/src/utils/mockTools.ts
@@ -1,0 +1,111 @@
+import type { ToolDefinition } from '../types';
+
+export const PRESET_TOOLS: ToolDefinition[] = [
+  {
+    id: 'preset-weather',
+    name: 'get_weather',
+    description: 'Get the current weather for a given location',
+    parameters: {
+      location: { type: 'string', description: 'City name, e.g. "San Francisco, CA"' },
+      unit: { type: 'string', description: 'Temperature unit', enum: ['celsius', 'fahrenheit'] },
+    },
+    required: ['location'],
+  },
+  {
+    id: 'preset-search',
+    name: 'web_search',
+    description: 'Search the web for information',
+    parameters: {
+      query: { type: 'string', description: 'The search query' },
+      num_results: { type: 'number', description: 'Number of results to return (1-10)' },
+    },
+    required: ['query'],
+  },
+  {
+    id: 'preset-calculate',
+    name: 'calculate',
+    description: 'Evaluate a mathematical expression',
+    parameters: {
+      expression: { type: 'string', description: 'The math expression to evaluate, e.g. "2 + 2 * 3"' },
+    },
+    required: ['expression'],
+  },
+];
+
+const MOCK_RESPONSES: Record<string, (args: Record<string, unknown>) => string> = {
+  get_weather: (args) => {
+    const unit = args.unit === 'celsius' ? 'C' : 'F';
+    const temp = args.unit === 'celsius' ? 22 : 72;
+    return JSON.stringify({
+      location: args.location,
+      temperature: temp,
+      unit: unit,
+      condition: 'Partly cloudy',
+      humidity: '65%',
+      wind: '12 mph NW',
+    });
+  },
+  web_search: (args) => {
+    return JSON.stringify({
+      query: args.query,
+      results: [
+        { title: `Top result for "${args.query}"`, url: 'https://example.com/1', snippet: 'This is a mock search result with relevant information...' },
+        { title: `Related: ${args.query} guide`, url: 'https://example.com/2', snippet: 'A comprehensive guide covering the topic in detail...' },
+      ],
+    });
+  },
+  calculate: (args) => {
+    try {
+      const expr = String(args.expression).replace(/[^0-9+\-*/().%\s]/g, '');
+      const result = new Function(`return (${expr})`)();
+      return JSON.stringify({ expression: args.expression, result });
+    } catch {
+      return JSON.stringify({ expression: args.expression, result: 'Error: invalid expression' });
+    }
+  },
+};
+
+export function executeMockTool(name: string, argsJson: string): string {
+  let args: Record<string, unknown>;
+  try {
+    args = JSON.parse(argsJson);
+  } catch {
+    return JSON.stringify({ error: 'Failed to parse tool arguments' });
+  }
+
+  const handler = MOCK_RESPONSES[name];
+  if (handler) {
+    return handler(args);
+  }
+
+  return JSON.stringify({
+    tool: name,
+    args,
+    result: `Mock result for ${name}. This is a simulated response.`,
+    status: 'success',
+  });
+}
+
+export function toolDefinitionsToApiFormat(tools: ToolDefinition[]) {
+  return tools.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description,
+      parameters: {
+        type: 'object',
+        properties: Object.fromEntries(
+          Object.entries(t.parameters).map(([key, param]) => [
+            key,
+            {
+              type: param.type,
+              description: param.description,
+              ...(param.enum ? { enum: param.enum } : {}),
+            },
+          ]),
+        ),
+        required: t.required,
+      },
+    },
+  }));
+}


### PR DESCRIPTION
- ToolEditor: add/edit/remove tool schemas with visual form or JSON editor, preset tools (get_weather, web_search, calculate), parameter management with type/required/enum support
- ToolCallMessage: renders tool calls in chat with collapsible blocks showing function name, arguments, and mock results
- ToolGuide: collapsible guide explaining tool calling concepts, schema format, and usage tips
- Mock execution: simulated tool results for get_weather, web_search, calculate; generic fallback for custom tools
- API updated to send tools array and handle tool_calls in responses
- App orchestrates tool call loop (up to 5 rounds) with automatic mock result injection and re-send to model for final answer
- Tool definitions and results persisted in localStorage

https://claude.ai/code/session_01BTZ8xdEMC1i59vqrmkyjZr